### PR TITLE
Adapt scripts and tokens to carbonswap

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "codegen": "graph codegen --output-dir src/types/",
     "build": "graph build",
-    "create-local": "graph create davekaj/uniswap --node http://127.0.0.1:8020",
-    "deploy-local": "graph deploy davekaj/uniswap --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
-    "deploy": "graph deploy ianlapham/uniswapv2 --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
-    "deploy-staging": "graph deploy $THE_GRAPH_GITHUB_USER/$THE_GRAPH_SUBGRAPH_NAME /Uniswap --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/",
-    "watch-local": "graph deploy graphprotocol/Uniswap2 --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001"
+    "create-local": "graph create carbonswap/analytics --node http://localhost:8020",
+    "create-prod": "graph create carbonswap/analytics --node https://ewc-api-graphql.carbonswap.exchange",
+    "deploy-local": "graph deploy carbonswap/analytics --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
+    "deploy-prod": "graph deploy carbonswap/analytics --ipfs https://ipfs.carbonswap.exchange --node https://ewc-api-graphql.carbonswap.exchange --debug",
+    "watch-local": "graph deploy carbonswap/analytics --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.16.0",

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-const */
-import { log, BigInt, BigDecimal, Address, EthereumEvent } from '@graphprotocol/graph-ts'
+import { log, BigInt, BigDecimal, Address, EthereumEvent, CallResult } from '@graphprotocol/graph-ts'
 import { ERC20 } from '../types/Factory/ERC20'
 import { ERC20SymbolBytes } from '../types/Factory/ERC20SymbolBytes'
 import { ERC20NameBytes } from '../types/Factory/ERC20NameBytes'
@@ -7,7 +7,7 @@ import { User, Bundle, Token, LiquidityPosition, LiquidityPositionSnapshot, Pair
 import { Factory as FactoryContract } from '../types/templates/Pair/Factory'
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
-export const FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
+export const FACTORY_ADDRESS = '0x17854c8d5a41d5A89B275386E24B2F38FD0AfbDd'
 
 export let ZERO_BI = BigInt.fromI32(0)
 export let ONE_BI = BigInt.fromI32(1)
@@ -55,11 +55,30 @@ export function isNullEthValue(value: string): boolean {
 
 export function fetchTokenSymbol(tokenAddress: Address): string {
   // hard coded overrides
-  if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
-    return 'DGD'
+
+  // if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
+  //   return 'DGD'
+  // }
+  // if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
+  //   return 'AAVE'
+  // }
+
+  if (
+    tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
+  ) {
+    return 'EDAI'  
   }
-  if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
-    return 'AAVE'
+
+  if (
+    tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
+  ) {
+    return 'OCEAN'
+  }
+
+  if (
+    tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
+  ) {
+    return 'SLR'
   }
 
   let contract = ERC20.bind(tokenAddress)
@@ -85,11 +104,30 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
 
 export function fetchTokenName(tokenAddress: Address): string {
   // hard coded overrides
-  if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
-    return 'DGD'
+
+  // if (tokenAddress.toHexString() == '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
+  //   return 'DGD'
+  // }
+  // if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
+  //   return 'Aave Token'
+  // }
+
+  if (
+    tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
+  ) {
+    return 'EDAI'  
   }
-  if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
-    return 'Aave Token'
+
+  if (
+    tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
+  ) {
+    return 'OCEAN'
+  }
+
+  if (
+    tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
+  ) {
+    return 'SLR'
   }
 
   let contract = ERC20.bind(tokenAddress)
@@ -114,6 +152,25 @@ export function fetchTokenName(tokenAddress: Address): string {
 }
 
 export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
+  // hardcoded overrrides
+  if (
+    tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
+  ) {
+    return BigInt.fromI32(1502) 
+  }
+
+  if (
+    tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
+  ) {
+    return BigInt.fromI32(2001) 
+  }
+
+  if (
+    tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
+  ) {
+    return BigInt.fromI32(38654130)
+  }
+
   let contract = ERC20.bind(tokenAddress)
   let totalSupplyValue = null
   let totalSupplyResult = contract.try_totalSupply()
@@ -125,9 +182,29 @@ export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
 
 export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   // hardcode overrides
-  if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
-    return BigInt.fromI32(18)
+
+  // if (tokenAddress.toHexString() == '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') {
+  //   return BigInt.fromI32(18)
+  // }
+
+  if (
+    tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
+  ) {
+    return BigInt.fromI32(18) 
   }
+
+  if (
+    tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
+  ) {
+    return BigInt.fromI32(18) 
+  }
+  
+  if (
+    tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
+  ) {
+    return BigInt.fromI32(38654130)
+  }
+  
 
   let contract = ERC20.bind(tokenAddress)
   // try types uint8 for decimals

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -63,23 +63,23 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
   //   return 'AAVE'
   // }
 
-  if (
-    tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
-  ) {
-    return 'EDAI'  
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
+  // ) {
+  //   return 'EDAI'  
+  // }
 
-  if (
-    tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
-  ) {
-    return 'OCEAN'
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
+  // ) {
+  //   return 'OCEAN'
+  // }
 
-  if (
-    tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
-  ) {
-    return 'SLR'
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
+  // ) {
+  //   return 'SLR'
+  // }
 
   let contract = ERC20.bind(tokenAddress)
   let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress)
@@ -112,23 +112,23 @@ export function fetchTokenName(tokenAddress: Address): string {
   //   return 'Aave Token'
   // }
 
-  if (
-    tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
-  ) {
-    return 'EDAI'  
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
+  // ) {
+  //   return 'EDAI'  
+  // }
 
-  if (
-    tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
-  ) {
-    return 'OCEAN'
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
+  // ) {
+  //   return 'OCEAN'
+  // }
 
-  if (
-    tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
-  ) {
-    return 'SLR'
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
+  // ) {
+  //   return 'SLR'
+  // }
 
   let contract = ERC20.bind(tokenAddress)
   let contractNameBytes = ERC20NameBytes.bind(tokenAddress)
@@ -153,23 +153,23 @@ export function fetchTokenName(tokenAddress: Address): string {
 
 export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
   // hardcoded overrrides
-  if (
-    tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
-  ) {
-    return BigInt.fromI32(1502) 
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
+  // ) {
+  //   return BigInt.fromI32(1502) 
+  // }
 
-  if (
-    tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
-  ) {
-    return BigInt.fromI32(2001) 
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
+  // ) {
+  //   return BigInt.fromI32(2001) 
+  // }
 
-  if (
-    tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
-  ) {
-    return BigInt.fromI32(38654130)
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
+  // ) {
+  //   return BigInt.fromI32(38654130)
+  // }
 
   let contract = ERC20.bind(tokenAddress)
   let totalSupplyValue = null
@@ -187,23 +187,23 @@ export function fetchTokenDecimals(tokenAddress: Address): BigInt {
   //   return BigInt.fromI32(18)
   // }
 
-  if (
-    tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
-  ) {
-    return BigInt.fromI32(18) 
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x3a9c927dd096070cff9e6b554e313cc047ea23f5'
+  // ) {
+  //   return BigInt.fromI32(18) 
+  // }
 
-  if (
-    tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
-  ) {
-    return BigInt.fromI32(18) 
-  }
-  
-  if (
-    tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
-  ) {
-    return BigInt.fromI32(38654130)
-  }
+  // if (
+  //   tokenAddress.toHexString() == '0x593122aae80a6fc3183b2ac0c4ab3336debee528'
+  // ) {
+  //   return BigInt.fromI32(18) 
+  // }
+
+  // if (
+  //   tokenAddress.toHexString() == '0x26e4991a72728b1a9b1044345e5bf9293e0a1434'
+  // ) {
+  //   return BigInt.fromI32(38654130)
+  // }
   
 
   let contract = ERC20.bind(tokenAddress)

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -3,7 +3,7 @@ import { Pair, Token, Bundle } from '../types/schema'
 import { BigDecimal, Address, BigInt } from '@graphprotocol/graph-ts/index'
 import { ZERO_BD, factoryContract, ADDRESS_ZERO, ONE_BD } from './helpers'
 
-const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+const WETH_ADDRESS = '0xe1BCdcd419Eb96d67D3eAb707FC108eD9172aDc7'
 const USDC_WETH_PAIR = '0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc' // created 10008355
 const DAI_WETH_PAIR = '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11' // created block 10042267
 const USDT_WETH_PAIR = '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852' // created block 10093341
@@ -40,22 +40,19 @@ export function getEthPriceInUSD(): BigDecimal {
 
 // token where amounts should contribute to tracked volume and liquidity
 let WHITELIST: string[] = [
-  '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+  '0xe1BCdcd419Eb96d67D3eAb707FC108eD9172aDc7', // WETH
   '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
-  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
-  '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
-  '0x0000000000085d4780b73119b644ae5ecd22b376', // TUSD
-  '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643', // cDAI
-  '0x39aa39c021dfbae8fac545936693ac917d5e7563', // cUSDC
-  '0x86fadb80d8d2cff3c3680819e4da99c10232ba0f', // EBASE
-  '0x57ab1ec28d129707052df4df418d58a2d46d5f51', // sUSD
-  '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2', // MKR
-  '0xc00e94cb662c3520282e6f5717214004a7f26888', // COMP
-  '0x514910771af9ca656af840dff83e8264ecf986ca', //LINK
-  '0x960b236a07cf122663c4303350609a66a7b288c0', //ANT
-  '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f', //SNX
-  '0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e', //YFI
-  '0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8' // yCurv
+  '0x9DaD43ee9E09837aeAca21799c88613e8E7c67dd', // USDC
+  '0x387f7D8D3360588a9A0B417F6C5DaAe64450942e', // USDT
+  '0xB75776e562Fea80bc94a1f57ED8337bc575E051B', //LINK
+  '0x7f8a0AdD824c125D88a51c15814A9a34e5238b88', // wBTC
+  '0x593122AAE80A6Fc3183b2AC0c4ab3336dEbeE528', // OCEAN
+  '0xA41eC761EE36c5986F7C47F80173f63fD039261d', // ALBT
+  '0x26E4991a72728b1a9B1044345e5bF9293E0A1434', // SLR
+  '0x6b3bd0478DF0eC4984b168Db0E12A539Cc0c83cd', // WEWT
+  '0xDb8B4264b1777e046267b4Cc123f0C9E029cEB2c', // WVT
+  '0x6AB434C660c38e8BDDF93F570CbC263104d31bA6', // fDAI
+  '0x94512DA6dA903606B15d4AfbE12333c1F7F65BeC', // SLR
 ]
 
 // minimum liquidity required to count towards tracked volume for pairs with small # of Lps

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -6,11 +6,12 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: Factory
-    network: mainnet
+    network: ewc
     source:
-      address: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
+      address: '0x17854c8d5a41d5A89B275386E24B2F38FD0AfbDd'
       abi: Factory
-      startBlock: 10000834
+      startBlock: 11354000 # needs to be -10k most (if not archive node)
+      # startBlock: 10970020 # actual start block of contract
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -34,7 +35,7 @@ dataSources:
 templates:
   - kind: ethereum/contract
     name: Pair
-    network: mainnet
+    network: ewc
     source:
       abi: Pair
     mapping:


### PR DESCRIPTION
Ignore the comments in helpers, this was to workaround not having an archive node (contract calls require archive). 

I updated price tracking of tokens (except for those hardcoded pairs) based on our token list and modified the NPM scripts and subgraph config. Before deployment, `startBlock` needs to be set to no more than `$currentBlockHeight` - 10k.  